### PR TITLE
タスクのデータをindexedDBに追加する処理を作成

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,13 @@
 import TaskBlock from "./components/TaskBlock"
+import TaskForm from "./components/TaskForm"
 
 function App() {
 
   return (
-    <TaskBlock />
+    <>
+      <TaskForm/>
+      <TaskBlock />
+    </>
   )
 }
 

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1,0 +1,41 @@
+import addTask from "../services/indexedDB/addTask";
+import createDB from "../services/indexedDB/createDB";
+
+const TaskForm = () => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+
+    const dbName = "yakDB";
+    const dbRequest = indexedDB.open(dbName);
+
+    dbRequest.onerror = (event) => {
+      console.error("error");
+      console.error(`Database error: ${JSON.stringify(event)}}`)
+    }
+    
+    dbRequest.onupgradeneeded = () => {
+      createDB(dbRequest);
+    }
+
+    dbRequest.onsuccess = () => {
+      const taskName = formData.get("taskName");
+      if (!taskName) {
+        console.log("no task name")
+        return;
+      }
+      addTask(dbRequest, taskName);
+    }
+  }
+  
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="text" name="taskName" placeholder="Write a Task" />
+      <button type="submit">Save Task</button>
+    </form>
+  )
+};
+
+export default TaskForm;

--- a/src/services/indexedDB/addTask.ts
+++ b/src/services/indexedDB/addTask.ts
@@ -1,0 +1,21 @@
+const addTask = (dbRequest: IDBOpenDBRequest, taskName: FormDataEntryValue) => {
+  const db = dbRequest.result;
+  const transaction = db.transaction(["tasks"], "readwrite");
+
+  const objectStore = transaction.objectStore("tasks");
+  const request = objectStore.add({taskName: taskName, status: "Waiting"});
+  request.onsuccess = () => {
+    console.log("task added");
+  }
+
+  transaction.oncomplete = () => {
+    console.log("All done!");
+  }
+
+  transaction.onerror = (event) => {
+    console.error("transaction error");
+    console.error(`Database error: ${JSON.stringify(event)}`)
+  }
+}
+
+export default addTask;

--- a/src/services/indexedDB/createDB.ts
+++ b/src/services/indexedDB/createDB.ts
@@ -1,0 +1,14 @@
+const createDB = (dbRequest: IDBOpenDBRequest) => {
+  const db = dbRequest.result;
+
+  const objectStore = db.createObjectStore('tasks', { keyPath: 'id', autoIncrement: true });
+  objectStore.createIndex("taskName", "taskName", {unique: false});
+  objectStore.createIndex("status", "status", {unique: false});
+
+
+  objectStore.transaction.oncomplete = () => {
+    console.log('create yakDB complete');
+  }
+}
+
+  export default createDB;


### PR DESCRIPTION
## やったこと

- indexedDBのテーブルを作成する処理を書きました
- indexedDBにタスクのデータを保存する処理を書きました

## とくに見て欲しいところ

- indexedDBの処理はViewから切り離したかったので、services/indexedDB/を作成して、そこにindexedDBの処理を書きました
- TaskForm.tsx内から、indexedDBの処理を十分に切り離し切れてないので、まだ改善の余地はありそうと思っている。

## 動作確認したこと

- indexedDBに入力したタスク名のデータが登録されることを確認

![image](https://github.com/yuya-0928/yak/assets/34731535/e0d5b967-8110-4658-80c3-aa011eb40a52)

