### PR TITLE
indexedDBにyakDBが無ければ、データベースを作る処理を追加

### DIFF
--- a/src/services/indexedDB/getAllTasks.ts
+++ b/src/services/indexedDB/getAllTasks.ts
@@ -1,8 +1,18 @@
 import { TaskType } from "../../types/TaskType";
+import createDB from "./createDB";
 
 const getAllTasks = () => {
   return new Promise<TaskType[]>((resolve, reject) => {
     const DBOpenRequest = window.indexedDB.open('yakDB');
+    DBOpenRequest.onupgradeneeded = () => {
+      const db = DBOpenRequest.result;
+
+      db.onerror = (err) => {
+        console.error('Error loading database.', err);
+      }
+      createDB(DBOpenRequest);
+    }
+    
     DBOpenRequest.onsuccess = () => {
       const db = DBOpenRequest.result;
       const transaction = db.transaction('tasks', 'readonly');


### PR DESCRIPTION
## やったこと

- getAllTasks実行時にデータベースが作成されていなかったら、yakDBを新たに作成する処理を書く

## とくに見て欲しいところ

-

## 動作確認したこと

- データベースを削除した状態でアプリを開き直すと、データベースが作成されること
- タスクの追加が問題なくできること
