### PR TITLE
タスクの論理削除を実装

### DIFF
--- a/src/components/TaskBlock.tsx
+++ b/src/components/TaskBlock.tsx
@@ -1,5 +1,8 @@
 import styled from "styled-components";
 import { TaskType } from "../types/TaskType";
+import deleteTask from "../services/indexedDB/deleteTask";
+import { useDispatch } from "react-redux";
+import { tasksUpdateNeeded } from "../functions/taskListSlice";
 
 const StyledTaskBlock = styled('div')`
   display: flex;
@@ -11,8 +14,15 @@ type Props = {
 }
 
 const TaskBlock: React.FC<Props> = ({task}) => {
+  const dispatch = useDispatch();
   const onChange = () => {
     console.log("task status changed");
+  }
+
+  const onTaskDelete = (taskId: number) => {
+    console.log("task deleted");
+    deleteTask(taskId);
+    dispatch(tasksUpdateNeeded());
   }
 
   return (
@@ -21,6 +31,7 @@ const TaskBlock: React.FC<Props> = ({task}) => {
       <p>TaskId:{task.id}</p>
       <p>TaskName:{task.taskName}</p>
       <p>Status:{task.status}</p>
+      <button onClick={() => {onTaskDelete(task.id)}}>delete</button>
     </StyledTaskBlock>
   )
 }

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import TaskBlock from "./TaskBlock";
-import getAllTasks from "../services/indexedDB/getAllTasks";
 import { TaskType } from "../types/TaskType";
 import { useSelector } from "../store";
 import { useDispatch } from "react-redux";
 import { tasksUpdateDone } from "../functions/taskListSlice";
+import getActiveTasks from "../services/indexedDB/getActiveTasks";
 
 
 const TaskList = () => {
@@ -15,8 +15,8 @@ const TaskList = () => {
   useEffect(() => {
     (async () => {
       try {
-        const allTasks = await getAllTasks();
-        setTasks(allTasks);
+        const activeTasks = await getActiveTasks();
+        setTasks(activeTasks);
       } catch (err) {
         console.error(err);
       }

--- a/src/services/indexedDB/addTask.ts
+++ b/src/services/indexedDB/addTask.ts
@@ -3,7 +3,7 @@ const addTask = (dbRequest: IDBOpenDBRequest, taskName: FormDataEntryValue) => {
   const transaction = db.transaction(["tasks"], "readwrite");
 
   const objectStore = transaction.objectStore("tasks");
-  const request = objectStore.add({taskName: taskName, status: "Waiting"});
+  const request = objectStore.add({taskName: taskName, status: "Waiting", isDeleted: 0});
   request.onsuccess = () => {
     console.log("task added");
   }

--- a/src/services/indexedDB/createDB.ts
+++ b/src/services/indexedDB/createDB.ts
@@ -4,6 +4,7 @@ const createDB = (dbRequest: IDBOpenDBRequest) => {
   const objectStore = db.createObjectStore('tasks', { keyPath: 'id', autoIncrement: true });
   objectStore.createIndex("taskName", "taskName", {unique: false});
   objectStore.createIndex("status", "status", {unique: false});
+  objectStore.createIndex("isDeleted", "isDeleted", {unique: false});
 
 
   objectStore.transaction.oncomplete = () => {

--- a/src/services/indexedDB/deleteTask.ts
+++ b/src/services/indexedDB/deleteTask.ts
@@ -1,0 +1,23 @@
+import accessDB from "./accessDB";
+
+const deleteTask = (taskId: number) => {
+  const DBOpenRequest = accessDB();
+
+    DBOpenRequest.onsuccess = () => {
+      const db = DBOpenRequest.result;
+      const objectStore = db.transaction(["tasks"], "readwrite").objectStore('tasks');
+      const objectStoreTaskRequest = objectStore.get(taskId);
+      objectStoreTaskRequest.onsuccess = () => {
+        const data = objectStoreTaskRequest.result;
+        data.isDeleted = 1;
+        const updateTaskRequest = objectStore.put(data);
+
+        updateTaskRequest.onsuccess = () => {
+          console.log("task updated");
+        }
+      }
+
+    }
+}
+
+export default deleteTask;

--- a/src/services/indexedDB/getActiveTasks.ts
+++ b/src/services/indexedDB/getActiveTasks.ts
@@ -1,0 +1,29 @@
+import { TaskType } from "../../types/TaskType";
+import accessDB from "./accessDB";
+
+const getActiveTasks = () => {
+  return new Promise<TaskType[]>((resolve, reject) => {
+    const DBOpenRequest = accessDB();
+
+    DBOpenRequest.onsuccess = () => {
+      const db = DBOpenRequest.result;
+      const transaction = db.transaction('tasks', 'readonly');
+      const objectStore = transaction.objectStore('tasks');
+      const index = objectStore.index('isDeleted');
+      const objectStoreRequest = index.getAll(IDBKeyRange.only(0));
+      objectStoreRequest.onsuccess = () => {
+        resolve(objectStoreRequest.result);
+      }
+
+      objectStoreRequest.onerror = (err) => {
+        reject(err);
+      }
+    }
+
+    DBOpenRequest.onerror = (err) => {
+      reject(err);
+    }
+  })
+};
+
+export default getActiveTasks;


### PR DESCRIPTION
## やったこと

- タスクの論理削除を実装しました

## とくに見て欲しいところ

- indexedDBでbooleanを持とうとすると、データの取得が上手く動作しないため、0,1を持たせる実装にしている

## 動作確認したこと

- タスクの削除ボタンを押すと、タスク一覧からタスクの表示が消えることを確認
